### PR TITLE
Add kingdom border display

### DIFF
--- a/Assets/Scripts/Display/DIsplay.cs
+++ b/Assets/Scripts/Display/DIsplay.cs
@@ -111,6 +111,8 @@ public class Display : MonoBehaviour
                     return $"<color={TextAtlas.Town}>{TextAtlas.townChar}</color>";
                 case WorldTile.POIType.Road:
                     return $"<color={TextAtlas.Road}>{TextAtlas.roadChar}</color>";
+                case WorldTile.POIType.Border:
+                    return $"<color={TextAtlas.Border}>{TextAtlas.borderChar}</color>";
                 default:
                     return TextAtlas.forest.ToString();
             }

--- a/Assets/Scripts/Display/TextAtlas.cs
+++ b/Assets/Scripts/Display/TextAtlas.cs
@@ -15,6 +15,7 @@
     public static readonly string AbandonMine = "#696969"; // DimGray
     public static readonly string Road = "#2F4F4F";        // DarkSlateGray
     public static readonly string Farm = "#8B4513";        // SaddleBrown
+    public static readonly string Border = "#FF00FF";      // Magenta for borders
 
     public static readonly string mountain = "#A9A9A9";    // Gray
     public static readonly string forest = "#228B22";      // Green
@@ -40,4 +41,5 @@
     public static readonly char abandonedMineChar = '⌂';
     public static readonly char roadChar = '=';
     public static readonly char farmChar = '◊';
+    public static readonly char borderChar = '#';
 }

--- a/Assets/Scripts/World/Generation/WorldGen.cs
+++ b/Assets/Scripts/World/Generation/WorldGen.cs
@@ -178,6 +178,8 @@ public class WorldGen : MonoBehaviour
             Game_Manager.Instance.displayPanels.UpdateLoadingText($"Region {i + 1}/{regions} and Kingdom {kingdom.KingdomName} complete.");
             kingdom.GenerateMyKingdomsRoads(100f);
         }
+
+        MarkBordersForAllRegions();
     }
 
     /// <summary>
@@ -556,6 +558,39 @@ public class WorldGen : MonoBehaviour
                 Rabbit rabbit = new Rabbit();
                 rabbit.SpawnRabbitNearPlayer(1);
                 currentSpawn++;
+            }
+        }
+    }
+
+    /// <summary>
+    /// Mark border tiles for all regions after generation.
+    /// Tiles that touch a tile from another region (or no region) become borders.
+    /// </summary>
+    private void MarkBordersForAllRegions()
+    {
+        Vector2Int[] directions = new Vector2Int[]
+        {
+            new Vector2Int(1,0), new Vector2Int(-1,0),
+            new Vector2Int(0,1), new Vector2Int(0,-1)
+        };
+
+        foreach (var region in Game_Manager.Instance.WorldRegions)
+        {
+            foreach (var tile in region.RegionTiles)
+            {
+                foreach (var dir in directions)
+                {
+                    WorldTilePos neighborPos = new WorldTilePos(tile.TileX + dir.x, tile.TileY + dir.y);
+                    if (worldData.WorldTileData.TryGetValue(neighborPos, out WorldTile neighbor))
+                    {
+                        if (neighbor.Region != tile.Region && tile.POI == WorldTile.POIType.None && !tile.IsRoad && !tile.IsTown)
+                        {
+                            tile.IsBorder = true;
+                            tile.POI = WorldTile.POIType.Border;
+                            break;
+                        }
+                    }
+                }
             }
         }
     }

--- a/Assets/Scripts/World/Tiles/WorldTile.cs
+++ b/Assets/Scripts/World/Tiles/WorldTile.cs
@@ -30,7 +30,8 @@ public class WorldTile
         Road,
         Mine,
         AbandonedMine,
-        Farm
+        Farm,
+        Border
     }
 
     public int TileX { get; set; }
@@ -45,6 +46,7 @@ public class WorldTile
     public bool IsPOI { get; set; } = false;
     public bool IsRoad { get; set; } = false;
     public bool IsTown { get; set; } = false;
+    public bool IsBorder { get; set; } = false;
     public WorldRegions Region { get; set; }
     public TownBase TownOnTile { get; set; }
     public IEntity EntityOnTile { get; set; }


### PR DESCRIPTION
## Summary
- mark border tiles between kingdoms when generating world
- add border POI type and visualization symbol
- draw borders in display using magenta `#`

## Testing
- `dotnet --version` *(fails: command not found)*