### PR TITLE
Fix POI display

### DIFF
--- a/Assets/Scripts/Display/LevelDisplay.cs
+++ b/Assets/Scripts/Display/LevelDisplay.cs
@@ -25,83 +25,54 @@ public class LevelDisplay : Display
     {
         if (Game_Manager.Instance.player.IsInLevel)
         {
-            StringBuilder worldBuilder = new StringBuilder();
-
-            for (int row = 0; row < rows; row++)
-            {
-                for (int col = 0; col < columns; col++)
+            BuildDisplay<LevelPOS>(
+                (x, y) => new LevelPOS(x, y),
+                pos =>
                 {
-                    int worldX = currentViewPos.x + col;
-                    int worldY = currentViewPos.y + row;
-                    LevelPOS posKey = new LevelPOS(worldX, worldY);
-
-                    string displayChar = " "; // default
-
-                    if (worldData.ActiveLevelData.TryGetValue(posKey, out LevelTile tile))
+                    if (LeveltileOverrides.TryGetValue(pos, out string ov))
+                        return ov;
+                    if (worldData.ActiveLevelData.TryGetValue(pos, out LevelTile tile))
                     {
-                        // Use an override if available.
-                        if (LeveltileOverrides.TryGetValue(posKey, out string overrideDisplay))
+                        if (tile.IsOccupiedByEnitiy)
                         {
-                            displayChar = overrideDisplay;
+                            return $"<color={tile.entity.entitySymbolColor}>{tile.entity.EntitySymbol}</color>";
+                        }
+                        else if (tile.IsOccupiedByFoliage)
+                        {
+                            return $"<color={tile.foliage.SymbolColor}>{tile.foliage.Symbol}</color>";
+                        }
+                        else if (tile.IsOccupiedByAttribute)
+                        {
+                            return $"<color={tile.attribute.SymbolColor}>{tile.attribute.Symbol}</color>";
+                        }
+                        else if (tile.IsOccupiedByBuilding)
+                        {
+                            switch (tile.BuildingPart)
+                            {
+                                case BuildingPart.Wall:
+                                    return $"<color={tile.Building.WallColor}>{tile.Building.BuildWallSymbol}</color>";
+                                case BuildingPart.Door:
+                                    return $"<color={tile.Building.DoorColorClosedColor}>{tile.Building.BuildDoorSymbol}</color>";
+                                case BuildingPart.Floor:
+                                    return $"<color={tile.Building.BuildingFloorColor}>{tile.Building.BuildFloorSymbol}</color>";
+                                case BuildingPart.Stairs:
+                                    return $"<color={tile.Building.StairsColor}>{tile.Building.BuildingStairsSymbol}</color>";
+                                default:
+                                    return $"<color={tile.Building.BuildingFloorColor}>{tile.Building.BuildFloorSymbol}</color>";
+                            }
                         }
                         else
                         {
-                            // If an entity is on the tile, show its symbol.
-                            if (tile.IsOccupiedByEnitiy)
-                            {
-                                displayChar = $"<color={tile.entity.entitySymbolColor}>{tile.entity.EntitySymbol}</color>";
-                            }
-                            else if (tile.IsOccupiedByFoliage)
-                            {
-                                displayChar = $"<color={tile.foliage.SymbolColor}>{tile.foliage.Symbol}</color>";
-                            }
-                            else if (tile.IsOccupiedByAttribute)
-                            {
-                                displayChar = $"<color={tile.attribute.SymbolColor}>{tile.attribute.Symbol}</color>";
-                            }
-                            else if (tile.IsOccupiedByBuilding)
-                            {
-                                switch (tile.BuildingPart)
-                                {
-                                    case BuildingPart.Wall:
-                                        displayChar = $"<color={tile.Building.WallColor}>{tile.Building.BuildWallSymbol}</color>";
-                                        break;
-                                    case BuildingPart.Door:
-                                        displayChar = $"<color={tile.Building.DoorColorClosedColor}>{tile.Building.BuildDoorSymbol}</color>";
-                                        break;
-                                    case BuildingPart.Floor:
-                                        displayChar = $"<color={tile.Building.BuildingFloorColor}>{tile.Building.BuildFloorSymbol}</color>";
-                                        break;
-                                    case BuildingPart.Stairs:
-                                        displayChar = $"<color={tile.Building.StairsColor}>{tile.Building.BuildingStairsSymbol}</color>";
-                                        break;
-                                    default:
-                                        displayChar = $"<color={tile.Building.BuildingFloorColor}>{tile.Building.BuildFloorSymbol}</color>";
-                                        break;
-                                }
-                            }
-                            else
-                            {
-                                displayChar = GetTileDisplay(tile);
-                            }
+                            return GetTileDisplay(tile);
                         }
                     }
-
-                    worldBuilder.Append(displayChar);
-                }
-                if (row < rows - 1)
-                {
-                    worldBuilder.AppendLine();
-                }
-            }
-
-            DisplayText.text = worldBuilder.ToString();
+                    return " ";
+                });
 
             // For debugging: count rows and columns.
             int rowCount, maxColumns;
             DisplayUtilities.CountRowsAndColumns(DisplayText.text, out rowCount, out maxColumns);
             Debug.Log($"Display built with {rowCount} rows and a maximum of {maxColumns} columns.");
-
         }
     }
 }

--- a/Assets/Scripts/Display/WorldDisplay.cs
+++ b/Assets/Scripts/Display/WorldDisplay.cs
@@ -30,46 +30,22 @@ public class WorldDisplay : Display
     {
         if (Game_Manager.Instance.player.IsInWorld)
         {
-            StringBuilder worldBuilder = new StringBuilder();
-
-            for (int row = 0; row < rows; row++)
-            {
-                for (int col = 0; col < columns; col++)
+            BuildDisplay<WorldTilePos>(
+                (x, y) => new WorldTilePos(x, y),
+                pos =>
                 {
-                    int worldX = currentViewPos.x + col;
-                    int worldY = currentViewPos.y + row;
-                    WorldTilePos posKey = new WorldTilePos(worldX, worldY);
-
-                    string displayChar = " "; // default
-
-                    if (worldData.WorldTileData.TryGetValue(posKey, out WorldTile tile))
+                    if (tileOverrides.TryGetValue(pos, out string ov))
+                        return ov;
+                    if (worldData.WorldTileData.TryGetValue(pos, out WorldTile tile))
                     {
-                        if (tileOverrides.TryGetValue(posKey, out string overrideDisplay))
+                        if (tile.HasEntityOnTile && tile.EntityOnTile != null)
                         {
-                            displayChar = overrideDisplay;
+                            return $"<color={tile.EntityOnTile.entitySymbolColor}>{tile.EntityOnTile.EntitySymbol}</color>";
                         }
-                        else
-                        {
-                            if (tile.HasEntityOnTile && tile.EntityOnTile != null)
-                            {
-                                displayChar = $"<color={tile.EntityOnTile.entitySymbolColor}>{tile.EntityOnTile.EntitySymbol}</color>";
-                            }
-                            else
-                            {
-                                displayChar = GetTileDisplay(tile);
-                            }
-                        }
+                        return GetTileDisplay(tile);
                     }
-
-                    worldBuilder.Append(displayChar);
-                }
-                if (row < rows - 1)
-                {
-                    worldBuilder.AppendLine();
-                }
-            }
-
-            DisplayText.text = worldBuilder.ToString();
+                    return " ";
+                });
         }
     }
 }

--- a/Assets/Scripts/System/Pathfinding/Pathfindier.cs
+++ b/Assets/Scripts/System/Pathfinding/Pathfindier.cs
@@ -18,11 +18,11 @@ public class Pathfindier
         public int hCost;  // Heuristic cost to the goal.
         public int fCost { get { return gCost + hCost; } }
         // For path reconstruction, 'parent' is used.
-        // (This code assumes that WorldTilePos is a reference type or a nullable struct.)
-        public WorldTilePos parent;
+        // Parent is nullable because WorldTilePos is a struct.
+        public WorldTilePos? parent;
         public Vector2Int direction; // The movement direction from the parent.
 
-        public Node(WorldTilePos pos, int g, int h, WorldTilePos parent, Vector2Int direction)
+        public Node(WorldTilePos pos, int g, int h, WorldTilePos? parent, Vector2Int direction)
         {
             this.position = pos;
             this.gCost = g;
@@ -149,9 +149,9 @@ public class Pathfindier
         List<WorldTilePos> path = new List<WorldTilePos>();
         path.Add(current);
         // Here we assume that a null parent indicates the start node.
-        while (cameFrom[current].parent != null)
+        while (cameFrom[current].parent.HasValue)
         {
-            current = cameFrom[current].parent;
+            current = cameFrom[current].parent.Value;
             path.Add(current);
         }
         path.Reverse();

--- a/Assets/Scripts/World/Generation/WorldGen.cs
+++ b/Assets/Scripts/World/Generation/WorldGen.cs
@@ -295,6 +295,7 @@ public class WorldGen : MonoBehaviour
                         ctile.IsTileTransversable = true;
                         ctile.IsPOI = true;
                         ctile.POI = WorldTile.POIType.Town;
+                        ctile.UpdateBaseDisplayString();
                         TownCapital.TownLocation = townTile;
                         TownCapital.IsCapital = true;
                         CapitalSet = true;
@@ -310,6 +311,7 @@ public class WorldGen : MonoBehaviour
                     tile.IsTileTransversable = false;
                     tile.IsPOI = true;
                     tile.POI = WorldTile.POIType.Town;
+                    tile.UpdateBaseDisplayString();
                     town.TownLocation = townTile;
 
                     Game_Manager.Instance.displayPanels.UpdateLoadingText($"Generating Towns");
@@ -587,6 +589,7 @@ public class WorldGen : MonoBehaviour
                         {
                             tile.IsBorder = true;
                             tile.POI = WorldTile.POIType.Border;
+                            tile.UpdateBaseDisplayString();
                             break;
                         }
                     }

--- a/Assets/Scripts/World/Kingdom/KingdomBase.cs
+++ b/Assets/Scripts/World/Kingdom/KingdomBase.cs
@@ -162,6 +162,7 @@ public class KingdomBase
                     Debug.Log($"Added: {roadPath.Count} roads to the world data.");
                     tile.IsPOI = false; // Roads are not POIs During world gen we will grab the tile type for the surrounding area.
                     tile.IsRoad = true;
+                    tile.UpdateBaseDisplayString();
                 }
             }
             Game_Manager.Instance.displayPanels.loadingtext.text = $"Road from {capital.TownName} to {town.TownName} generated.";

--- a/Assets/Scripts/World/Kingdom/KingdomTiles/Farm.cs
+++ b/Assets/Scripts/World/Kingdom/KingdomTiles/Farm.cs
@@ -33,6 +33,7 @@ public class Farm : KingdomTile
             tile.IsPOI = true;
             tile.POI = WorldTile.POIType.Farm;
             setFertility(tile);
+            tile.UpdateBaseDisplayString();
         }
         Type = KingdomTileType.Farm;
         kingdomOwner.KingdomTiles.Add(this);
@@ -51,6 +52,7 @@ public class Farm : KingdomTile
             tile.IsPOI = true;
             tile.POI = WorldTile.POIType.Farm;
             setFertility(tile);
+            tile.UpdateBaseDisplayString();
         }
         Type = KingdomTileType.Farm;
         kingdomOwner.KingdomTiles.Add(this);
@@ -66,6 +68,7 @@ public class Farm : KingdomTile
             tile.IsPOI = true;
             tile.POI = WorldTile.POIType.Farm;
             setFertility(tile);
+            tile.UpdateBaseDisplayString();
         }
         Type = KingdomTileType.Farm;
     }
@@ -80,6 +83,7 @@ public class Farm : KingdomTile
             tile.IsPOI = true;
             tile.POI = WorldTile.POIType.Farm;
             setFertility(tile);
+            tile.UpdateBaseDisplayString();
         }
         TownInfluencer = town;
         Type = KingdomTileType.Farm;

--- a/Assets/Scripts/World/Kingdom/KingdomTiles/Mine.cs
+++ b/Assets/Scripts/World/Kingdom/KingdomTiles/Mine.cs
@@ -25,6 +25,7 @@ public class Mine : KingdomTile
             tile.IsTileTransversable = false;
             tile.IsPOI = true;
             tile.POI = WorldTile.POIType.Mine;
+            tile.UpdateBaseDisplayString();
         }
         Type = KingdomTileType.Mine;
         kingdomOwner.KingdomTiles.Add(this);
@@ -43,6 +44,7 @@ public class Mine : KingdomTile
             tile.IsTileTransversable = false;
             tile.IsPOI = true;
             tile.POI = WorldTile.POIType.Mine;
+            tile.UpdateBaseDisplayString();
         }
         Type = KingdomTileType.Mine;
         kingdomOwner.KingdomTiles.Add(this);
@@ -59,6 +61,7 @@ public class Mine : KingdomTile
             tile.IsTileTransversable = false;
             tile.IsPOI = true;
             tile.POI = WorldTile.POIType.Mine;
+            tile.UpdateBaseDisplayString();
         }
         Type = KingdomTileType.Mine;
     }
@@ -74,6 +77,7 @@ public class Mine : KingdomTile
             tile.IsTileTransversable = false;
             tile.IsPOI = true;
             tile.POI = WorldTile.POIType.Mine;
+            tile.UpdateBaseDisplayString();
         }
         TownInfluencer = town;
         Type = KingdomTileType.Mine;

--- a/Assets/Scripts/World/Tiles/LevelTile.cs
+++ b/Assets/Scripts/World/Tiles/LevelTile.cs
@@ -34,6 +34,9 @@ public class LevelTile
     public bool IsOccupiedByAttribute = false; // Not All Attributes are bad. Some are good.
     public bool IsOccupiedByBuilding = false;
 
+    // Cached base display string
+    public string BaseDisplayString { get; private set; }
+
     /// <summary>
     /// 
     /// </summary>
@@ -49,12 +52,49 @@ public class LevelTile
         { TileZ = 0; }
         MyPosition = new LevelPOS(x, y, z);
         MyParentsPosition = new WorldTilePos(x, y);
+
+        UpdateBaseDisplayString();
     }
     public LevelTile() { }
+
+    public void UpdateBaseDisplayString()
+    {
+        if (Biome == TileEnums.LevelTileBiome.Forest)
+        {
+            switch (ForestTileType)
+            {
+                case TileEnums.ForestTiles.LushFloor:
+                    BaseDisplayString = $"<color={TextAtlas.ForestFloorLush}>{TextAtlas.ForestFloorLushChar}</color>";
+                    break;
+                case TileEnums.ForestTiles.DirtFloor:
+                    BaseDisplayString = $"<color={TextAtlas.ForestFloorDirt}>{TextAtlas.ForestFloorDirtChar}</color>";
+                    break;
+                case TileEnums.ForestTiles.GrassFloor:
+                    BaseDisplayString = $"<color={TextAtlas.ForestFloorGrass}>{TextAtlas.ForestFloorGrassChar}</color>";
+                    break;
+                case TileEnums.ForestTiles.MudFloor:
+                    BaseDisplayString = $"<color={TextAtlas.ForestFloorMud}>{TextAtlas.ForestFloorMudChar}</color>";
+                    break;
+                case TileEnums.ForestTiles.LeavesFloor:
+                    BaseDisplayString = $"<color={TextAtlas.ForestFloorLeaves}>{TextAtlas.ForestFloorLeavesChar}</color>";
+                    break;
+                case TileEnums.ForestTiles.RockyGroundFloor:
+                    BaseDisplayString = $"<color={TextAtlas.ForestFloorRockyGround}>{TextAtlas.ForestFloorRockyGroundChar}</color>";
+                    break;
+                default:
+                    BaseDisplayString = $"<color={TextAtlas.ForestFloorLush}>{TextAtlas.ForestFloorLushChar}</color>";
+                    break;
+            }
+        }
+        else
+        {
+            BaseDisplayString = $"<color={TextAtlas.forest}>{TextAtlas.forestChar}</color>";
+        }
+    }
 }
 
 
-public class LevelPOS : IEquatable<LevelPOS>
+public struct LevelPOS : IEquatable<LevelPOS>
 {
     public readonly int x;
     public readonly int y;
@@ -78,7 +118,7 @@ public class LevelPOS : IEquatable<LevelPOS>
 
     public bool Equals(LevelPOS other)
     {
-        return other != null && this.x == other.x && this.y == other.y;
+        return this.x == other.x && this.y == other.y;
     }
 
     public override int GetHashCode()
@@ -94,10 +134,6 @@ public class LevelPOS : IEquatable<LevelPOS>
 
     public static bool operator ==(LevelPOS left, LevelPOS right)
     {
-        if (ReferenceEquals(left, right))
-            return true;
-        if (left is null || right is null)
-            return false;
         return left.Equals(right);
     }
 

--- a/Assets/Scripts/World/Tiles/WorldTile.cs
+++ b/Assets/Scripts/World/Tiles/WorldTile.cs
@@ -60,6 +60,9 @@ public class WorldTile
     public float MonsterDensity { get; set; }
     public float ResourceDensity { get; set; }
 
+    // Cached display string for rendering performance
+    public string BaseDisplayString { get; private set; }
+
     public WorldTile(int x, int y, WorldTileType tileType = WorldTileType.Ground)
     {
         TileX = x;
@@ -86,6 +89,8 @@ public class WorldTile
         {
             Features.Add("Snow");
         }
+
+        UpdateBaseDisplayString();
     }
     /// <summary>
     /// Gets the Density of the tile and returns it as a percentage in a string.
@@ -113,6 +118,62 @@ public class WorldTile
     {
         IsTown = true;
         TownOnTile = town;
+        UpdateBaseDisplayString();
+    }
+
+    public void UpdateBaseDisplayString()
+    {
+        if (IsPOI || IsRoad)
+        {
+            switch (POI)
+            {
+                case POIType.Mine:
+                    BaseDisplayString = $"<color={TextAtlas.Mine}>{TextAtlas.mineChar}</color>";
+                    break;
+                case POIType.AbandonedMine:
+                    BaseDisplayString = $"<color={TextAtlas.AbandonMine}>{TextAtlas.abandonedMineChar}</color>";
+                    break;
+                case POIType.Farm:
+                    BaseDisplayString = $"<color={TextAtlas.Farm}>{TextAtlas.farmChar}</color>";
+                    break;
+                case POIType.Town:
+                    BaseDisplayString = $"<color={TextAtlas.Town}>{TextAtlas.townChar}</color>";
+                    break;
+                case POIType.Road:
+                    BaseDisplayString = $"<color={TextAtlas.Road}>{TextAtlas.roadChar}</color>";
+                    break;
+                case POIType.Border:
+                    BaseDisplayString = $"<color={TextAtlas.Border}>{TextAtlas.borderChar}</color>";
+                    break;
+                default:
+                    BaseDisplayString = TextAtlas.forest.ToString();
+                    break;
+            }
+        }
+        else
+        {
+            switch (TileType)
+            {
+                case WorldTileType.Water:
+                    BaseDisplayString = $"<color={TextAtlas.water}>{TextAtlas.waterChar}</color>";
+                    break;
+                case WorldTileType.Desert:
+                    BaseDisplayString = $"<color={TextAtlas.desert}>{TextAtlas.desertChar}</color>";
+                    break;
+                case WorldTileType.Forest:
+                    BaseDisplayString = $"<color={TextAtlas.forest}>{TextAtlas.forestChar}</color>";
+                    break;
+                case WorldTileType.Mountain:
+                    BaseDisplayString = $"<color={TextAtlas.mountain}>{TextAtlas.mountainChar}</color>";
+                    break;
+                case WorldTileType.Snow:
+                    BaseDisplayString = $"<color={TextAtlas.snow}>{TextAtlas.snowChar}</color>";
+                    break;
+                default:
+                    BaseDisplayString = $"<color={TextAtlas.forest}>{TextAtlas.forestChar}</color>";
+                    break;
+            }
+        }
     }
 
     bool SetTransversable(WorldTileType type)
@@ -134,7 +195,7 @@ public class WorldTile
 /// <summary>
 /// Represents a position in the world.
 /// </summary>
-public sealed class WorldTilePos : IEquatable<WorldTilePos>
+public struct WorldTilePos : IEquatable<WorldTilePos>
 {
     public readonly int x;
     public readonly int y;
@@ -152,7 +213,7 @@ public sealed class WorldTilePos : IEquatable<WorldTilePos>
 
     public bool Equals(WorldTilePos other)
     {
-        return other != null && this.x == other.x && this.y == other.y;
+        return this.x == other.x && this.y == other.y;
     }
 
     public override int GetHashCode()
@@ -168,10 +229,6 @@ public sealed class WorldTilePos : IEquatable<WorldTilePos>
 
     public static bool operator ==(WorldTilePos left, WorldTilePos right)
     {
-        if (ReferenceEquals(left, right))
-            return true;
-        if (left is null || right is null)
-            return false;
         return left.Equals(right);
     }
 


### PR DESCRIPTION
## Summary
- update base display strings whenever world tiles become towns, roads, farms, mines, or borders
- ensure SetTownOnTile refreshes display text

## Testing
- `dotnet build` *(fails: command not found)*