### PR TITLE
Add plains, swamp and jungle biomes

### DIFF
--- a/Assets/Scripts/Display/TextAtlas.cs
+++ b/Assets/Scripts/Display/TextAtlas.cs
@@ -21,6 +21,9 @@
     public static readonly string forest = "#228B22";      // Green
     public static readonly string desert = "#FFD700";      // Yellow
     public static readonly string snow = "#FFFFFF";        // White
+    public static readonly string plains = "#9ACD32";      // YellowGreen
+    public static readonly string swamp = "#556B2F";       // DarkOliveGreen
+    public static readonly string jungle = "#006400";      // DarkGreen
 
     // Forest Floor Tiles Characters
     public static readonly string ForestFloorLushChar = ".";
@@ -36,6 +39,9 @@
     public static readonly char forestChar = '*';
     public static readonly char desertChar = '-';
     public static readonly char snowChar = '+';
+    public static readonly char plainsChar = '.';
+    public static readonly char swampChar = '%';
+    public static readonly char jungleChar = '@';
     public static readonly char townChar = '¶';
     public static readonly char mineChar = '⌂';
     public static readonly char abandonedMineChar = '⌂';

--- a/Assets/Scripts/World/Generation/WorldGen.cs
+++ b/Assets/Scripts/World/Generation/WorldGen.cs
@@ -19,10 +19,16 @@ public class WorldGen : MonoBehaviour
     public float waterThreshold = 0.7f;
     [Tooltip("Tiles with noise values below this become desert.")]
     public float desertThreshold = 0.76f;
+    [Tooltip("Tiles with noise values below this become plains.")]
+    public float plainsThreshold = 0.82f;
     [Tooltip("Tiles with noise values below this become forest.")]
     public float forestThreshold = 0.88f;
+    [Tooltip("Tiles with noise values below this become swamp.")]
+    public float swampThreshold = 0.92f;
+    [Tooltip("Tiles with noise values below this become jungle.")]
+    public float jungleThreshold = 0.96f;
     [Tooltip("Tiles with noise values below this become mountain.")]
-    public float mountainThreshold = 0.95f;
+    public float mountainThreshold = 0.98f;
     // Tiles with noise values above mountainThreshold become snow.
 
     private System.Random random = new System.Random();
@@ -74,9 +80,21 @@ public class WorldGen : MonoBehaviour
                 {
                     tileType = WorldTile.WorldTileType.Desert;
                 }
+                else if (noiseValue < plainsThreshold)
+                {
+                    tileType = WorldTile.WorldTileType.Plains;
+                }
                 else if (noiseValue < forestThreshold)
                 {
                     tileType = WorldTile.WorldTileType.Forest;
+                }
+                else if (noiseValue < swampThreshold)
+                {
+                    tileType = WorldTile.WorldTileType.Swamp;
+                }
+                else if (noiseValue < jungleThreshold)
+                {
+                    tileType = WorldTile.WorldTileType.Jungle;
                 }
                 else if (noiseValue < mountainThreshold)
                 {

--- a/Assets/Scripts/World/Tiles/TileEnums.cs
+++ b/Assets/Scripts/World/Tiles/TileEnums.cs
@@ -6,6 +6,9 @@ public class TileEnums
     {
         Forest,
         Desert,
+        Plains,
+        Swamp,
+        Jungle,
         Mountain,
         Snow,
         Water,

--- a/Assets/Scripts/World/Tiles/WorldTile.cs
+++ b/Assets/Scripts/World/Tiles/WorldTile.cs
@@ -21,7 +21,10 @@ public class WorldTile
         Mountain,
         Forest,
         Desert,
-        Snow
+        Snow,
+        Plains,
+        Swamp,
+        Jungle
     }
     public enum POIType
     { 
@@ -160,8 +163,17 @@ public class WorldTile
                 case WorldTileType.Desert:
                     BaseDisplayString = $"<color={TextAtlas.desert}>{TextAtlas.desertChar}</color>";
                     break;
+                case WorldTileType.Plains:
+                    BaseDisplayString = $"<color={TextAtlas.plains}>{TextAtlas.plainsChar}</color>";
+                    break;
                 case WorldTileType.Forest:
                     BaseDisplayString = $"<color={TextAtlas.forest}>{TextAtlas.forestChar}</color>";
+                    break;
+                case WorldTileType.Swamp:
+                    BaseDisplayString = $"<color={TextAtlas.swamp}>{TextAtlas.swampChar}</color>";
+                    break;
+                case WorldTileType.Jungle:
+                    BaseDisplayString = $"<color={TextAtlas.jungle}>{TextAtlas.jungleChar}</color>";
                     break;
                 case WorldTileType.Mountain:
                     BaseDisplayString = $"<color={TextAtlas.mountain}>{TextAtlas.mountainChar}</color>";
@@ -215,8 +227,17 @@ public class WorldTile
                 case WorldTileType.Desert:
                     BaseDisplayString = $"<color={TextAtlas.desert}>{TextAtlas.desertChar}</color>";
                     break;
+                case WorldTileType.Plains:
+                    BaseDisplayString = $"<color={TextAtlas.plains}>{TextAtlas.plainsChar}</color>";
+                    break;
                 case WorldTileType.Forest:
                     BaseDisplayString = $"<color={TextAtlas.forest}>{TextAtlas.forestChar}</color>";
+                    break;
+                case WorldTileType.Swamp:
+                    BaseDisplayString = $"<color={TextAtlas.swamp}>{TextAtlas.swampChar}</color>";
+                    break;
+                case WorldTileType.Jungle:
+                    BaseDisplayString = $"<color={TextAtlas.jungle}>{TextAtlas.jungleChar}</color>";
                     break;
                 case WorldTileType.Mountain:
                     BaseDisplayString = $"<color={TextAtlas.mountain}>{TextAtlas.mountainChar}</color>";
@@ -233,7 +254,7 @@ public class WorldTile
 
     bool SetTransversable(WorldTileType type)
     {
-        if (type == WorldTileType.Water || type == WorldTileType.Mountain)
+        if (type == WorldTileType.Water || type == WorldTileType.Mountain || type == WorldTileType.Swamp)
         {
             return false;
 


### PR DESCRIPTION
## Summary
- extend WorldTileType and LevelTileBiome enums with new biome values
- add colors and characters for plains, swamp and jungle
- handle new biomes in WorldTile display and traversal logic
- extend WorldGen thresholds and generation to place the new biomes

## Testing
- `git status --short`