### PR TITLE
Add swamp and jungle biomes

### DIFF
--- a/Assets/Scripts/Display/TextAtlas.cs
+++ b/Assets/Scripts/Display/TextAtlas.cs
@@ -8,6 +8,20 @@
     public static readonly string ForestFloorLeaves = "#6B8E23";       // OliveDrab for leafy areas
     public static readonly string ForestFloorRockyGround = "#708090";  // SlateGray for rocky ground
 
+    // Swamp Floor Tiles Colors
+    public static readonly string SwampFloorWater = "#2E8B57";
+    public static readonly string SwampFloorMud = "#5B3A29";
+    public static readonly string SwampFloorGrass = "#556B2F";
+    public static readonly string SwampFloorMoss = "#6B8E23";
+    public static readonly string SwampFloorRockyGround = "#696969";
+
+    // Jungle Floor Tiles Colors
+    public static readonly string JungleFloorLush = "#228B22";
+    public static readonly string JungleFloorDirt = "#8B4513";
+    public static readonly string JungleFloorGrass = "#006400";
+    public static readonly string JungleFloorMud = "#734F25";
+    public static readonly string JungleFloorRockyGround = "#808080";
+
     // World Tiles Colors
     public static readonly string water = "#1E90FF";       // DodgerBlue
     public static readonly string Town = "#FFD700";        // Gold
@@ -33,6 +47,20 @@
     public static readonly string ForestFloorLeavesChar = ".";
     public static readonly string ForestFloorRockyGroundChar = ".";
 
+    // Swamp Floor Tiles Characters
+    public static readonly string SwampFloorWaterChar = "~";
+    public static readonly string SwampFloorMudChar = ".";
+    public static readonly string SwampFloorGrassChar = ".";
+    public static readonly string SwampFloorMossChar = ".";
+    public static readonly string SwampFloorRockyGroundChar = ".";
+
+    // Jungle Floor Tiles Characters
+    public static readonly string JungleFloorLushChar = ".";
+    public static readonly string JungleFloorDirtChar = ".";
+    public static readonly string JungleFloorGrassChar = ".";
+    public static readonly string JungleFloorMudChar = ".";
+    public static readonly string JungleFloorRockyGroundChar = ".";
+
     // World Tile Characters
     public static readonly char waterChar = '~';
     public static readonly char mountainChar = '^';
@@ -49,3 +77,4 @@
     public static readonly char farmChar = '◊';
     public static readonly char borderChar = '#';
 }
+

--- a/Assets/Scripts/Entity/PlayerEnity/Player.cs
+++ b/Assets/Scripts/Entity/PlayerEnity/Player.cs
@@ -136,10 +136,18 @@ public class Player : PlayerBase
             if (worldData.WorldTileData.TryGetValue(entityWorldPos, out WorldTile MyTile))
             {
                 LevelGen generator = new LevelGen();
-                if (MyTile.TileType == WorldTile.WorldTileType.Forest)
+                Game_Manager.Instance.PlayerLoadingIntoBiome = true;
+                switch (MyTile.TileType)
                 {
-                    Game_Manager.Instance.PlayerLoadingIntoBiome = true;
-                    generator.GenerateForestLevel(MyTile);
+                    case WorldTile.WorldTileType.Forest:
+                        generator.GenerateForestLevel(MyTile);
+                        break;
+                    case WorldTile.WorldTileType.Swamp:
+                        generator.GenerateSwampLevel(MyTile);
+                        break;
+                    case WorldTile.WorldTileType.Jungle:
+                        generator.GenerateJungleLevel(MyTile);
+                        break;
                 }
             }
         }
@@ -366,4 +374,5 @@ public class Player : PlayerBase
         levelDisplay.BuildWorldDisplay();
     }
 }
+
 

--- a/Assets/Scripts/World/Generation/LevelGen.cs
+++ b/Assets/Scripts/World/Generation/LevelGen.cs
@@ -23,6 +23,26 @@ public class LevelGen : MonoBehaviour
         Game_Manager.Instance.levelDisplay.SetLevelSize(LevelX, LevelY);
         forestGen.GenerateLevel();
     }
+
+    public void GenerateSwampLevel(WorldTile tile)
+    {
+        SwampTileGen swampGen = new SwampTileGen(tile);
+        swampGen.TileSizeX = LevelX;
+        swampGen.TileSizeY = LevelY;
+        swampGen.TileSizeZ = LevelZ;
+        Game_Manager.Instance.levelDisplay.SetLevelSize(LevelX, LevelY);
+        swampGen.GenerateLevel();
+    }
+
+    public void GenerateJungleLevel(WorldTile tile)
+    {
+        JungleTileGen jungleGen = new JungleTileGen(tile);
+        jungleGen.TileSizeX = LevelX;
+        jungleGen.TileSizeY = LevelY;
+        jungleGen.TileSizeZ = LevelZ;
+        Game_Manager.Instance.levelDisplay.SetLevelSize(LevelX, LevelY);
+        jungleGen.GenerateLevel();
+    }
     public void GenerateHumanTownLevel(WorldTile tile)
     {
         // Create an instance of your HumanTownGen to generate a town level.
@@ -38,3 +58,4 @@ public class LevelGen : MonoBehaviour
     {
     }
 }
+

--- a/Assets/Scripts/World/Generation/LevelTypeGens/Biomes/JungleTileGen.cs
+++ b/Assets/Scripts/World/Generation/LevelTypeGens/Biomes/JungleTileGen.cs
@@ -1,0 +1,91 @@
+using System.Collections.Generic;
+using UnityEngine;
+using static TileEnums;
+
+public class JungleTileGen : TileGenBase
+{
+    public float TreeDensity { get; private set; }
+    public float MonsterDensity { get; private set; }
+    public float ResourceDensity { get; private set; }
+
+    public int TileSizeX = 100;
+    public int TileSizeY = 100;
+    public WorldTile Tile { get; private set; }
+
+    public List<TreeBase> Trees { get; private set; }
+
+    public JungleTileGen(WorldTile tile)
+    {
+        Tile = tile;
+        TreeDensity = 0.12f;
+        MonsterDensity = tile.MonsterDensity;
+        ResourceDensity = tile.ResourceDensity;
+        SetTrees();
+    }
+
+    public override void GenerateLevel()
+    {
+        Dictionary<LevelPOS, LevelTile> generatedLevel = new Dictionary<LevelPOS, LevelTile>();
+
+        float noiseScale = 0.1f;
+        float offsetX = Random.Range(0f, 100f);
+        float offsetY = Random.Range(0f, 100f);
+
+        for (int x = 0; x < TileSizeX; x++)
+        {
+            for (int y = 0; y < TileSizeY; y++)
+            {
+                float noise = Mathf.PerlinNoise((x + offsetX) * noiseScale,
+                                               (y + offsetY) * noiseScale);
+                JungleTiles floorType = DetermineFloorType(noise);
+
+                LevelTile tile = new LevelTile
+                {
+                    TileX = x,
+                    TileY = y,
+                    Biome = LevelTileBiome.Jungle,
+                    JungleTileType = floorType,
+                    IsTransversable = true
+                };
+
+                if ((floorType == JungleTiles.LushFloor || floorType == JungleTiles.GrassFloor) &&
+                    Trees != null && Trees.Count > 0 && Random.value < TreeDensity)
+                {
+                    TreeBase tree = Trees[Random.Range(0, Trees.Count)];
+                    tile.foliage = tree;
+                    tile.IsOccupiedByFoliage = true;
+                    tile.IsTransversable = false;
+                }
+
+                generatedLevel.Add(new LevelPOS(x, y, 0), tile);
+            }
+        }
+
+        Game_Manager.Instance.worldData.ActiveLevelData = generatedLevel;
+        Debug.Log("Jungle level generated with " + generatedLevel.Count + " tiles.");
+        Game_Manager.Instance.LoadLevel();
+    }
+
+    private JungleTiles DetermineFloorType(float noise)
+    {
+        if (noise < 0.2f)
+            return JungleTiles.DirtFloor;
+        else if (noise < 0.4f)
+            return JungleTiles.MudFloor;
+        else if (noise < 0.8f)
+            return JungleTiles.LushFloor;
+        else if (noise < 0.9f)
+            return JungleTiles.GrassFloor;
+        else
+            return JungleTiles.RockyGroundFloor;
+    }
+
+    private void SetTrees()
+    {
+        TreeBase banana = new TreeBase(TreeBase.TreeType.Banana, "#228B22");
+        TreeBase palm = new TreeBase(TreeBase.TreeType.Palm, "#008000");
+        TreeBase mango = new TreeBase(TreeBase.TreeType.Mango, "#FFD700");
+        Trees = new List<TreeBase> { banana, palm, mango };
+    }
+}
+

--- a/Assets/Scripts/World/Generation/LevelTypeGens/Biomes/JungleTileGen.cs.meta
+++ b/Assets/Scripts/World/Generation/LevelTypeGens/Biomes/JungleTileGen.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: 4a382df47fb2ab4419dd2456370d0ee4

--- a/Assets/Scripts/World/Generation/LevelTypeGens/Biomes/SwampTileGen.cs
+++ b/Assets/Scripts/World/Generation/LevelTypeGens/Biomes/SwampTileGen.cs
@@ -1,0 +1,90 @@
+using System.Collections.Generic;
+using UnityEngine;
+using static TileEnums;
+
+public class SwampTileGen : TileGenBase
+{
+    public float TreeDensity { get; private set; }
+    public float MonsterDensity { get; private set; }
+    public float ResourceDensity { get; private set; }
+
+    public int TileSizeX = 100;
+    public int TileSizeY = 100;
+    public WorldTile Tile { get; private set; }
+
+    public List<TreeBase> Trees { get; private set; }
+
+    public SwampTileGen(WorldTile tile)
+    {
+        Tile = tile;
+        TreeDensity = 0.05f;
+        MonsterDensity = tile.MonsterDensity;
+        ResourceDensity = tile.ResourceDensity;
+        SetTrees();
+    }
+
+    public override void GenerateLevel()
+    {
+        Dictionary<LevelPOS, LevelTile> generatedLevel = new Dictionary<LevelPOS, LevelTile>();
+
+        float noiseScale = 0.1f;
+        float offsetX = Random.Range(0f, 100f);
+        float offsetY = Random.Range(0f, 100f);
+
+        for (int x = 0; x < TileSizeX; x++)
+        {
+            for (int y = 0; y < TileSizeY; y++)
+            {
+                float noise = Mathf.PerlinNoise((x + offsetX) * noiseScale,
+                                               (y + offsetY) * noiseScale);
+                SwampTiles floorType = DetermineFloorType(noise);
+
+                LevelTile tile = new LevelTile
+                {
+                    TileX = x,
+                    TileY = y,
+                    Biome = LevelTileBiome.Swamp,
+                    SwampTileType = floorType,
+                    IsTransversable = true
+                };
+
+                if ((floorType == SwampTiles.MudFloor || floorType == SwampTiles.GrassFloor) &&
+                    Trees != null && Trees.Count > 0 && Random.value < TreeDensity)
+                {
+                    TreeBase tree = Trees[Random.Range(0, Trees.Count)];
+                    tile.foliage = tree;
+                    tile.IsOccupiedByFoliage = true;
+                    tile.IsTransversable = false;
+                }
+
+                generatedLevel.Add(new LevelPOS(x, y, 0), tile);
+            }
+        }
+
+        Game_Manager.Instance.worldData.ActiveLevelData = generatedLevel;
+        Debug.Log("Swamp level generated with " + generatedLevel.Count + " tiles.");
+        Game_Manager.Instance.LoadLevel();
+    }
+
+    private SwampTiles DetermineFloorType(float noise)
+    {
+        if (noise < 0.25f)
+            return SwampTiles.WaterFloor;
+        else if (noise < 0.5f)
+            return SwampTiles.MudFloor;
+        else if (noise < 0.75f)
+            return SwampTiles.GrassFloor;
+        else if (noise < 0.9f)
+            return SwampTiles.MossFloor;
+        else
+            return SwampTiles.RockyGroundFloor;
+    }
+
+    private void SetTrees()
+    {
+        TreeBase cypress = new TreeBase(TreeBase.TreeType.Cypress, "#556B2F");
+        TreeBase willow = new TreeBase(TreeBase.TreeType.Willow, "#6B8E23");
+        Trees = new List<TreeBase> { cypress, willow };
+    }
+}
+

--- a/Assets/Scripts/World/Generation/LevelTypeGens/Biomes/SwampTileGen.cs.meta
+++ b/Assets/Scripts/World/Generation/LevelTypeGens/Biomes/SwampTileGen.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: 4a382df47fb2ab4419dd2456370d0ee4

--- a/Assets/Scripts/World/Tiles/LevelTile.cs
+++ b/Assets/Scripts/World/Tiles/LevelTile.cs
@@ -23,6 +23,8 @@ public class LevelTile
 
     public LevelTileBiome Biome { get; set; }
     public ForestTiles ForestTileType { get; set; }
+    public SwampTiles SwampTileType { get; set; }
+    public JungleTiles JungleTileType { get; set; }
 
     public bool IsVisible = false;
     public bool IsExplored = false;
@@ -83,6 +85,54 @@ public class LevelTile
                     break;
                 default:
                     BaseDisplayString = $"<color={TextAtlas.ForestFloorLush}>{TextAtlas.ForestFloorLushChar}</color>";
+                    break;
+            }
+        }
+        else if (Biome == TileEnums.LevelTileBiome.Swamp)
+        {
+            switch (SwampTileType)
+            {
+                case TileEnums.SwampTiles.WaterFloor:
+                    BaseDisplayString = $"<color={TextAtlas.SwampFloorWater}>{TextAtlas.SwampFloorWaterChar}</color>";
+                    break;
+                case TileEnums.SwampTiles.MudFloor:
+                    BaseDisplayString = $"<color={TextAtlas.SwampFloorMud}>{TextAtlas.SwampFloorMudChar}</color>";
+                    break;
+                case TileEnums.SwampTiles.GrassFloor:
+                    BaseDisplayString = $"<color={TextAtlas.SwampFloorGrass}>{TextAtlas.SwampFloorGrassChar}</color>";
+                    break;
+                case TileEnums.SwampTiles.MossFloor:
+                    BaseDisplayString = $"<color={TextAtlas.SwampFloorMoss}>{TextAtlas.SwampFloorMossChar}</color>";
+                    break;
+                case TileEnums.SwampTiles.RockyGroundFloor:
+                    BaseDisplayString = $"<color={TextAtlas.SwampFloorRockyGround}>{TextAtlas.SwampFloorRockyGroundChar}</color>";
+                    break;
+                default:
+                    BaseDisplayString = $"<color={TextAtlas.SwampFloorGrass}>{TextAtlas.SwampFloorGrassChar}</color>";
+                    break;
+            }
+        }
+        else if (Biome == TileEnums.LevelTileBiome.Jungle)
+        {
+            switch (JungleTileType)
+            {
+                case TileEnums.JungleTiles.LushFloor:
+                    BaseDisplayString = $"<color={TextAtlas.JungleFloorLush}>{TextAtlas.JungleFloorLushChar}</color>";
+                    break;
+                case TileEnums.JungleTiles.DirtFloor:
+                    BaseDisplayString = $"<color={TextAtlas.JungleFloorDirt}>{TextAtlas.JungleFloorDirtChar}</color>";
+                    break;
+                case TileEnums.JungleTiles.GrassFloor:
+                    BaseDisplayString = $"<color={TextAtlas.JungleFloorGrass}>{TextAtlas.JungleFloorGrassChar}</color>";
+                    break;
+                case TileEnums.JungleTiles.MudFloor:
+                    BaseDisplayString = $"<color={TextAtlas.JungleFloorMud}>{TextAtlas.JungleFloorMudChar}</color>";
+                    break;
+                case TileEnums.JungleTiles.RockyGroundFloor:
+                    BaseDisplayString = $"<color={TextAtlas.JungleFloorRockyGround}>{TextAtlas.JungleFloorRockyGroundChar}</color>";
+                    break;
+                default:
+                    BaseDisplayString = $"<color={TextAtlas.JungleFloorLush}>{TextAtlas.JungleFloorLushChar}</color>";
                     break;
             }
         }

--- a/Assets/Scripts/World/Tiles/TileEnums.cs
+++ b/Assets/Scripts/World/Tiles/TileEnums.cs
@@ -27,4 +27,21 @@ public class TileEnums
         LeavesFloor,
         RockyGroundFloor
     }
+    public enum SwampTiles
+    {
+        WaterFloor,
+        MudFloor,
+        GrassFloor,
+        MossFloor,
+        RockyGroundFloor
+    }
+
+    public enum JungleTiles
+    {
+        LushFloor,
+        DirtFloor,
+        GrassFloor,
+        MudFloor,
+        RockyGroundFloor
+    }
 }


### PR DESCRIPTION
## Summary
- support new floor enumerations for Swamp and Jungle biomes
- show swamp and jungle tiles with new colors and characters
- add SwampTileGen and JungleTileGen
- generate the correct biome level in LevelGen and Player controls

## Testing
- `dotnet build` *(fails: command not found)*