### PR TITLE
Allow spawn on any traversable biome

### DIFF
--- a/Assets/Scripts/System/Game_Manager.cs
+++ b/Assets/Scripts/System/Game_Manager.cs
@@ -144,10 +144,8 @@ public class Game_Manager : MonoBehaviour
         }
         foreach (var tile in worldData.WorldTileData)
         {
-            if (tile.Value.TileType == WorldTile.WorldTileType.Forest ||
-                tile.Value.TileType == WorldTile.WorldTileType.Desert)
+            if (tile.Value.IsTileTransversable)
             {
-                // Use tile.Key directly or create a new instance if needed.
                 tilesList.Add(new WorldTilePos(tile.Key.x, tile.Key.y));
             }
         }


### PR DESCRIPTION
## Summary
- broaden player spawn logic to accept any tile flagged `IsTileTransversable`

## Testing
- `dotnet` not installed; no build attempted