### PR TITLE
Use LevelGen singleton

### DIFF
--- a/Assets/Scripts/Entity/PlayerEnity/Player.cs
+++ b/Assets/Scripts/Entity/PlayerEnity/Player.cs
@@ -33,7 +33,12 @@ public class Player : PlayerBase
         {
             if (worldData.WorldTileData.TryGetValue(entityWorldPos, out WorldTile currentTile))
             {
-                LevelGen generator = new LevelGen();
+                LevelGen generator = Game_Manager.Instance.levelGen;
+                if (generator == null)
+                {
+                    Debug.LogError("LevelGen not assigned!");
+                    return;
+                }
                 Game_Manager.Instance.PlayerLoadingIntoBiome = true;
 
                 switch (currentTile.TileType)

--- a/Assets/Scripts/System/Targetting/WorldInteractionCliker.cs
+++ b/Assets/Scripts/System/Targetting/WorldInteractionCliker.cs
@@ -64,7 +64,12 @@ public class WorldInteractionCliker : MonoBehaviour, IPointerClickHandler
                     // Look up the tile data directly.
                     if (worldData.WorldTileData.TryGetValue(posKey, out WorldTile tile))
                     {
-                        LevelGen generator = new LevelGen();
+                        LevelGen generator = Game_Manager.Instance.levelGen;
+                        if (generator == null)
+                        {
+                            Debug.LogError("LevelGen not assigned!");
+                            return;
+                        }
                         if (tile.IsTown)
                         {
                             Debug.Log($"Clicked Town at {posKey.x}, {posKey.y}.");


### PR DESCRIPTION
## Summary
- use `Game_Manager.Instance.levelGen` instead of creating new `LevelGen` objects
- log an error when `levelGen` is missing

## Testing
- `grep -n "new LevelGen" -R Assets/Scripts | wc -l`