### PR TITLE
Fix LevelTile key creation

### DIFF
--- a/Assets/Scripts/World/WorldData.cs
+++ b/Assets/Scripts/World/WorldData.cs
@@ -31,7 +31,7 @@ public class WorldData : MonoBehaviour
     }
     public void AddTile(LevelTile tile, Dictionary<LevelPOS, LevelTile> data)
     {
-        var pos = new LevelPOS(tile.TileX, tile.TileY, tile.TileY);
+        var pos = new LevelPOS(tile.TileX, tile.TileY, tile.TileZ);
         if (!data.ContainsKey(pos))
         {
             data.Add(pos, tile);


### PR DESCRIPTION
## Summary
- use `tile.TileZ` when constructing the LevelPOS in `AddTile`

## Testing
- `dotnet build` *(fails: command not found)*